### PR TITLE
Masking options

### DIFF
--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -49,7 +49,7 @@ class Background(_ImageParser):
         cross-dispersion axis
         [default: 0]
     mask_treatment : string, optional
-        The method for handling masked or non-finite data. Choice of `filter`,
+        The method for handling masked or non-finite data. Choice of ``filter``,
         ``omit``, or ``zero-fill``. If ``filter`` is chosen, masked and non-finite
         data will not contribute to the background statistic that is calculated
         in each column along `disp_axis`. If `omit` is chosen, columns along

--- a/specreduce/background.py
+++ b/specreduce/background.py
@@ -114,7 +114,8 @@ class Background(_ImageParser):
         # Parse image, including masked/nonfinite data handling based on
         # choice of `mask_treatment`. Any uncaught nonfinte data values will be
         # masked as well. Returns a Spectrum1D.
-        self.image = self._parse_image(self.image)
+        self.image = self._parse_image(self.image, disp_axis=self.disp_axis,
+                                       mask_treatment=self.mask_treatment)
 
         # always work with masked array, even if there is no masked
         # or nonfinite data, in case padding is needed. if not, mask will be

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -30,22 +30,28 @@ class _ImageParser:
 
     implemented_mask_treatment_methods = 'filter', 'zero-fill', 'omit'
 
-    def _parse_image(self, image, disp_axis=1):
+    def _parse_image(self, image,
+                     disp_axis: int = 1,
+                     mask_treatment: str = 'filter') -> Spectrum1D:
         """
-        Convert all accepted image types to a consistently formatted
-        Spectrum1D object.
+        Convert all accepted image types to a consistently formatted Spectrum1D object.
 
         Parameters
         ----------
-        image : `~astropy.nddata.NDData`-like or array-like, required
+        image : `~astropy.nddata.NDData`-like or array-like
             The image to be parsed. If None, defaults to class' own
             image attribute.
-        disp_axis : int, optional
+        disp_axis
             The index of the image's dispersion axis. Should not be
             changed until operations can handle variable image
             orientations. [default: 1]
-        """
+        mask_treatment
+            Treatment method for the mask.
 
+        Returns
+        -------
+        Spectrum1D
+        """
         # would be nice to handle (cross)disp_axis consistently across
         # operations (public attribute? private attribute? argument only?) so
         # it can be called from self instead of via kwargs...
@@ -54,9 +60,8 @@ class _ImageParser:
             # useful for Background's instance methods
             return self.image
 
-        img = self._get_data_from_image(image, disp_axis=disp_axis)
-
-        return img
+        return self._get_data_from_image(image, disp_axis=disp_axis,
+                                        mask_treatment=mask_treatment)
 
     @staticmethod
     def _get_data_from_image(image,
@@ -73,7 +78,10 @@ class _ImageParser:
         disp_axis : int, optional
             The dispersion axis of the image.
         mask_treatment : str, optional
-            Treatment method for the mask.
+            Treatment method for the mask:
+            - 'filter' (default): Return the unmodified input image and combined mask.
+            - 'zero-fill': Set masked values in the image to zero.
+            - 'omit': Mask all pixels along the cross dispersion axis if any value is masked.
 
         Returns
         -------

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -61,7 +61,7 @@ class _ImageParser:
             return self.image
 
         return self._get_data_from_image(image, disp_axis=disp_axis,
-                                        mask_treatment=mask_treatment)
+                                         mask_treatment=mask_treatment)
 
     @staticmethod
     def _get_data_from_image(image,

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -28,6 +28,8 @@ class _ImageParser:
         - `~numpy.ndarray`
     """
 
+    # The '_valid_mask_treatment_methods' in the Background, Trace, and Extract
+    # classes is a subset of implemented methods.
     implemented_mask_treatment_methods = 'filter', 'zero-fill', 'omit'
 
     def _parse_image(self, image,

--- a/specreduce/core.py
+++ b/specreduce/core.py
@@ -48,7 +48,17 @@ class _ImageParser:
             changed until operations can handle variable image
             orientations. [default: 1]
         mask_treatment
-            Treatment method for the mask.
+            The method for handling masked or non-finite data. Choice of ``filter``,
+            ``omit``, or ``zero-fill``. If ``filter`` is chosen, masked and non-finite
+            data will not contribute to the background statistic that is calculated
+            in each column along `disp_axis`. If `omit` is chosen, columns along
+            disp_axis with any masked/non-finite data values will be fully masked
+            (i.e, 2D mask is collapsed to 1D and applied). If ``zero-fill`` is chosen,
+            masked/non-finite data will be replaced with 0.0 in the input image,
+            and the mask will then be dropped. For all three options, the input mask
+            (optional on input NDData object) will be combined with a mask generated
+            from any non-finite values in the image data.
+            [default: ``filter``]
 
         Returns
         -------
@@ -150,8 +160,9 @@ class _ImageParser:
         ----------
         image : array-like
             The input image data array that may contain nonfinite values.
-        mask : array-like or None
-            An optional mask array. Nonfinite values in the image will be added to this mask.
+        mask : array-like of bool or None
+            An optional Boolean mask array. Nonfinite values in the image will be added
+            to this mask.
         mask_treatment : str
             Specifies how to handle masked data:
             - 'filter' (default): Returns the unmodified input image and combined mask.

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -213,7 +213,7 @@ class BoxcarExtract(SpecreduceOperation):
         # Parse image, including masked/nonfinite data handling based on
         # choice of `mask_treatment`, which for BoxcarExtract can be filter, zero-fill, or
         # omit. non-finite data will be masked, always. Returns a Spectrum1D.
-        self.image = self._parse_image(image)
+        self.image = self._parse_image(image, disp_axis=disp_axis, mask_treatment=self.mask_treatment)
 
         # # _parse_image returns a Spectrum1D. convert this to a masked array
         # # for ease of calculations here (even if there is no masked data).

--- a/specreduce/extract.py
+++ b/specreduce/extract.py
@@ -213,7 +213,8 @@ class BoxcarExtract(SpecreduceOperation):
         # Parse image, including masked/nonfinite data handling based on
         # choice of `mask_treatment`, which for BoxcarExtract can be filter, zero-fill, or
         # omit. non-finite data will be masked, always. Returns a Spectrum1D.
-        self.image = self._parse_image(image, disp_axis=disp_axis, mask_treatment=self.mask_treatment)
+        self.image = self._parse_image(image, disp_axis=disp_axis,
+                                       mask_treatment=self.mask_treatment)
 
         # # _parse_image returns a Spectrum1D. convert this to a masked array
         # # for ease of calculations here (even if there is no masked data).

--- a/specreduce/tests/test_tracing.py
+++ b/specreduce/tests/test_tracing.py
@@ -252,7 +252,7 @@ class TestMasksTracing():
 
         # ensure correct warning is raised when entire trace is masked.
         trace_arr = np.ma.MaskedArray([1, 2, np.nan, 4, 5], mask=[1, 1, 0, 1, 1])
-        with pytest.raises(UserWarning, match=r'Entire trace array is masked.'):
+        with pytest.warns(UserWarning, match=r'Entire trace array is masked.'):
             array_trace = ArrayTrace(img, trace_arr)
 
     def test_fit_trace_fully_masked_image(self):

--- a/specreduce/tracing.py
+++ b/specreduce/tracing.py
@@ -287,7 +287,8 @@ class FitTrace(Trace, _ImageParser):
 
         # Parse image, including masked/nonfinite data handling based on
         # choice of `mask_treatment`. returns a Spectrum1D
-        self.image = self._parse_image(self.image)
+        self.image = self._parse_image(self.image, disp_axis=self._disp_axis,
+                                       mask_treatment=self.mask_treatment)
 
         # _parse_image returns a Spectrum1D. convert this to a masked array
         # for ease of calculations here (even if there is no masked data).


### PR DESCRIPTION
This PR offers one way to include the mask-handling functionality without requiring a major refactoring of the `_ImageParser` class and all the code that depends on it.  I've changed the `_mask_and_nonfinite_data_handling` method into a static method that takes the cross-dispersion axis and mask treatment as optional arguments (that I've added to the `_get_data_from_image` and `_parse_image` methods as well),  and I've changed all the code using the methods to include this information when necessary. 

I've tried to take a minimalistic approach and modify only what I think is really necessary to make the mask treatment work with the current `_ImageParser` architecture. I'm afraid we will still need to do a major refactoring of image parsing, but this will require a bit of discussion and can be done in a dedicated PR. 

The approach passes all the tests without failures (including codestyle). I also made a minor change in `test_tracing.py` to test that a warning is raised using `pytest.warns` instead of `pytest.raises`, and  merged the recent contributions to the main repo and branch by pllim.